### PR TITLE
Correctly find all messages

### DIFF
--- a/src/MailhogClient.php
+++ b/src/MailhogClient.php
@@ -46,7 +46,7 @@ class MailhogClient
                     '%s/api/v2/messages?limit=%d&start=%d',
                     $this->baseUri,
                     $limit,
-                    ++$start
+                    $start
                 )
             );
 
@@ -61,6 +61,8 @@ class MailhogClient
             foreach ($allMessageData['items'] as $messageData) {
                 yield MessageFactory::fromMailhogResponse($messageData);
             }
+
+            $start += $limit;
         }
     }
 

--- a/tests/integration/MailhogClientTest.php
+++ b/tests/integration/MailhogClientTest.php
@@ -136,15 +136,28 @@ class MailhogClientTest extends TestCase
     {
         for ($i = 0; $i < 5; $i++) {
             $this->sendMessage(
-                $this->createBasicMessage('me@myself.example', 'myself@myself.example', 'Test subject', 'Test body')
+                $this->createBasicMessage('me@myself.example', 'myself@myself.example', 'Test subject '.$i, 'Test body')
             );
         }
 
-        $messages = $this->client->findAllMessages(1);
+        $messages = $this->client->findAllMessages(2);
 
         $this->assertInstanceOf(Generator::class, $messages);
 
-        $this->assertCount(5, iterator_to_array($messages));
+        $messages = iterator_to_array($messages);
+
+        $this->assertCount(5, $messages);
+
+        $allSubjects = \array_map(
+            function (Message $message) {
+                return $message->subject;
+            },
+            $messages
+        );
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->assertContains('Test subject '.$i, $allSubjects);
+        }
     }
 
     /**


### PR DESCRIPTION
The previous implementation was incorrect and would return way more
messages than asked for with a lot of duplicates once it actually
started paging.