### PR TITLE
Add support for HTTPlug 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,20 +24,20 @@
         "php": "^7.2",
 	    "ext-json": "*",
         "php-http/client-implementation": "^1.0",
-        "php-http/httplug": "^1.0",
+        "php-http/httplug": "^1.0|^2.0",
         "php-http/message-factory": "^1.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "guzzlehttp/psr7": "^1.4",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "phpmd/phpmd": "^2.1.2",
         "phpunit/phpunit": "^8.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.0",
         "squizlabs/php_codesniffer": "^3.4",
         "swiftmailer/swiftmailer": "^6.2",
         "phpstan/phpstan": "^0.11",
         "pdepend/pdepend": "^2.5",
-        "maglnet/composer-require-checker": "^2.0"
+        "maglnet/composer-require-checker": "^2.0",
+        "nyholm/psr7": "^1.2"
     }
 }

--- a/tests/integration/MailhogClientTest.php
+++ b/tests/integration/MailhogClientTest.php
@@ -6,6 +6,7 @@ namespace rpkamp\Mailhog\Tests\integration;
 use Generator;
 use Http\Client\Curl\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Nyholm\Psr7\Factory\HttplugFactory;
 use PHPUnit\Framework\TestCase;
 use rpkamp\Mailhog\MailhogClient;
 use rpkamp\Mailhog\Message\Mime\Attachment;
@@ -30,7 +31,7 @@ class MailhogClientTest extends TestCase
 
     public function setUp(): void
     {
-        $this->client = new MailhogClient(new Client(), new GuzzleMessageFactory(), $_ENV['mailhog_api_uri']);
+        $this->client = new MailhogClient(new Client(), new HttplugFactory(), $_ENV['mailhog_api_uri']);
         $this->client->purgeMessages();
     }
 


### PR DESCRIPTION
And switched to nyholm/psr-7 instead of guzzle/psr7 because HTTPlug 2.0
requires a PSR-17 factory, and guzzle/psr7 doesn't supply that.