### PR TITLE
Breaking out of loop when start is greater than or equal to total

### DIFF
--- a/src/MailhogClient.php
+++ b/src/MailhogClient.php
@@ -63,15 +63,15 @@ class MailhogClient
 
             $allMessageData = json_decode($response->getBody()->getContents(), true);
 
-            if (0 === $allMessageData['count']) {
-                return; // all done!
-            }
-
             foreach ($allMessageData['items'] as $messageData) {
                 yield MessageFactory::fromMailhogResponse($messageData);
             }
 
             $start += $limit;
+
+            if ($start >= $allMessageData['total']) {
+                return;
+            }
         }
     }
 

--- a/src/Message/Contact.php
+++ b/src/Message/Contact.php
@@ -27,6 +27,7 @@ class Contact
 
     public static function fromString(string $contact): Contact
     {
+        $matches = [];
         if (preg_match('~^(?P<name>.*?)\s+<(?P<email>\S*?)>$~i', $contact, $matches)) {
             return new self($matches['email'], stripslashes(trim($matches['name'])));
         }

--- a/src/Message/Mime/MimePart.php
+++ b/src/Message/Mime/MimePart.php
@@ -60,6 +60,7 @@ class MimePart
         if (isset($mimePart['Headers']['Content-Disposition'][0]) &&
             stripos($mimePart['Headers']['Content-Disposition'][0], 'attachment') === 0
         ) {
+            $matches = [];
             preg_match('~filename=(?P<filename>.*?)(;|$)~i', $mimePart['Headers']['Content-Disposition'][0], $matches);
             $filename = $matches['filename'];
         }


### PR DESCRIPTION
Thanks for this client, I have been using it with the behat extension and is providing me an easy way to test emails being sent from my apps :D

Unfortunately it seems that Mailhog will still return results even if the start parameter is out of bounds (using the latest version from docker hub: https://hub.docker.com/r/mailhog/mailhog not sure if it's also the case with different versions). Resulting, in my case, in an infinite loop.

This change avoids having to make an extra request to find out that there are no more results and fixes the problem where there might be results returned when the start parameter is out of bounds.

Thanks in advance for reviewing!