### PR TITLE
Decode mime headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": "^7.2",
 	    "ext-json": "*",
+        "ext-iconv": "*",
         "php-http/client-implementation": "^1.0",
         "php-http/httplug": "^1.0|^2.0",
         "php-http/message-factory": "^1.0",
@@ -30,7 +31,7 @@
     },
     "require-dev": {
         "jakub-onderka/php-parallel-lint": "^1.0",
-        "phpmd/phpmd": "^2.1.2",
+        "phpmd/phpmd": "~2.8.0",
         "phpunit/phpunit": "^8.0",
         "php-http/curl-client": "^2.0",
         "swiftmailer/swiftmailer": "^6.2",

--- a/src/Message/Headers.php
+++ b/src/Message/Headers.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace rpkamp\Mailhog\Message;
+
+use function iconv_mime_decode;
+use function strtolower;
+
+class Headers
+{
+    /**
+     * @var array<string, string> $headers
+     */
+    private $headers;
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public function __construct(array $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * @param array<mixed, mixed> $mailhogResponse
+     */
+    public static function fromMailhogResponse(array $mailhogResponse): self
+    {
+        return self::fromRawHeaders($mailhogResponse['Content']['Headers'] ?? []);
+    }
+
+    /**
+     * @param array<mixed, mixed> $mimePart
+     */
+    public static function fromMimePart(array $mimePart): self
+    {
+        return self::fromRawHeaders($mimePart['Headers']);
+    }
+
+    /**
+     * @param array<string, array<string>> $rawHeaders
+     */
+    private static function fromRawHeaders(array $rawHeaders): self
+    {
+        $headers = [];
+        foreach ($rawHeaders as $name => $header) {
+            if (!isset($header[0])) {
+                continue;
+            }
+
+            $decoded = iconv_mime_decode($header[0]);
+
+            $headers[strtolower($name)] = $decoded ? $decoded : $header[0];
+        }
+
+        return new Headers($headers);
+    }
+
+    public function get(string $name, string $default = ''): string
+    {
+        $name = strtolower($name);
+
+        if (isset($this->headers[$name])) {
+            return $this->headers[$name];
+        }
+
+        return $default;
+    }
+
+    public function has(string $name): bool
+    {
+        $name = strtolower($name);
+
+        return isset($this->headers[$name]);
+    }
+}

--- a/tests/unit/Message/Fixtures/sample_mailhog_response.json
+++ b/tests/unit/Message/Fixtures/sample_mailhog_response.json
@@ -1,0 +1,78 @@
+{
+  "total":1,
+  "count":1,
+  "start":0,
+  "items":[
+    {
+      "ID":"1SepfeC9XRP7xKMDmPfczx8k3ktwjh605ZVatm4L9ew=@mailhog.example",
+      "From":{
+        "Relays":null,
+        "Mailbox":"no-reply",
+        "Domain":"myself.example",
+        "Params":""
+      },
+      "To":[
+        {
+          "Relays":null,
+          "Mailbox":"jose",
+          "Domain":"myself.example",
+          "Params":""
+        },
+        {
+          "Relays":null,
+          "Mailbox":"leticia",
+          "Domain":"myself.example",
+          "Params":""
+        }
+      ],
+      "Content":{
+        "Headers":{
+          "Content-Transfer-Encoding":[
+            "quoted-printable"
+          ],
+          "Content-Type":[
+            "text/html; charset=utf-8"
+          ],
+          "Date":[
+            "Sun, 06 Sep 2020 15:24:56 -0300"
+          ],
+          "From":[
+            "=?utf-8?Q?Jos=C3=A9?= de tal \u003cno-reply@myself.example\u003e"
+          ],
+          "MIME-Version":[
+            "1.0"
+          ],
+          "Message-ID":[
+            "\u003c3f91997768d3c98ab3e19cebb5a731f8@swift.generated\u003e"
+          ],
+          "Received":[
+            "from [127.0.0.1] by mailhog.example (MailHog)\r\n          id 1SepfeC9XRP7xKMDmPfczx8k3ktwjh605ZVatm4L9ew=@mailhog.example; Sun, 06 Sep 2020 18:24:56 +0000"
+          ],
+          "Return-Path":[
+            "\u003cno-reply@myself.example\u003e"
+          ],
+          "Subject":[
+            "Mailhog =?utf-8?Q?=C3=A9?= muito bom mesmo: =?utf-8?Q?=F0=9F=98=81?="
+          ],
+          "To":[
+            "=?utf-8?Q?Jos=C3=A9?= \u003cjose@myself.example\u003e, =?utf-8?Q?Let=C3=ADcia_maranh=C3=A3o?= \u003cleticia@myself.example\u003e"
+          ]
+        },
+        "Body":"foobar",
+        "Size":474,
+        "MIME":null
+      },
+      "Created":"2020-09-06T18:24:56.58754722Z",
+      "MIME":null,
+      "Raw":{
+        "From":"no-reply@myself.example",
+        "To":[
+          "jose@myself.example",
+          "leticia@myself.example"
+        ],
+        "Data":"Message-ID: \u003c3f91997768d3c98ab3e19cebb5a731f8@swift.generated\u003e\r\nDate: Sun, 06 Sep 2020 15:24:56 -0300\r\nSubject: Mailhog =?utf-8?Q?=C3=A9?= muito bom mesmo:\r\n =?utf-8?Q?=F0=9F=98=81?=\r\nFrom: =?utf-8?Q?Jos=C3=A9?= de tal \u003cno-reply@myself.example\u003e\r\nTo: =?utf-8?Q?Jos=C3=A9?= \u003cjose@myself.example\u003e,\r\n =?utf-8?Q?Let=C3=ADcia_maranh=C3=A3o?= \u003cleticia@myself.example\u003e\r\nMIME-Version: 1.0\r\nContent-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\nfoobar",
+        "Helo":"[127.0.0.1]"
+      }
+    }
+  ]
+}

--- a/tests/unit/Message/HeadersTest.php
+++ b/tests/unit/Message/HeadersTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace rpkamp\Mailhog\Tests\unit\Message;
+
+use PHPUnit\Framework\TestCase;
+use rpkamp\Mailhog\Message\Headers;
+
+class HeadersTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_parse_headers(): void
+    {
+        $messageData = $this->getMessageData();
+        $headers = Headers::fromMailHogResponse($messageData);
+
+        $this->assertEquals(
+            "Mailhog é muito bom mesmo: 😁",
+            $headers->get("Subject")
+        );
+
+        $this->assertEquals(
+            "José <jose@myself.example>, Letícia maranhão <leticia@myself.example>",
+            $headers->get("To")
+        );
+
+        $this->assertEquals(
+            "José de tal <no-reply@myself.example>",
+            $headers->get("From")
+        );
+
+        $this->assertEquals(
+            "quoted-printable",
+            $headers->get("Content-Transfer-Encoding")
+        );
+
+        $this->assertEquals(
+            "text/html; charset=utf-8",
+            $headers->get("Content-Type")
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_ignore_case_for_the_header_name(): void
+    {
+        $messageData = $this->getMessageData();
+        $headers = Headers::fromMailHogResponse($messageData);
+
+        $this->assertEquals(
+            "José de tal <no-reply@myself.example>",
+            $headers->get("from")
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_the_default_value_when_the_header_does_not_exist(): void
+    {
+        $headers = new Headers([]);
+
+        $this->assertEquals(
+            'default value',
+            $headers->get('foobar', 'default value')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_check_if_a_header_exists(): void
+    {
+        $headers = new Headers([]);
+        $this->assertFalse($headers->has('foobar'));
+    }
+
+    /**
+     * @return array<mixed, mixed>
+     */
+    private function getMessageData(): array
+    {
+        $contents = file_get_contents(__DIR__ . '/Fixtures/sample_mailhog_response.json');
+        if (!$contents) {
+            return [];
+        }
+
+        $allMessagesData = json_decode($contents, true);
+        return $allMessagesData['items'][0];
+    }
+}


### PR DESCRIPTION
 The email headers in the response body from mailhog are encoded, which makes working with utf-8 characters non-intuitive.
    
A new abstraction for the headers was created in order to encapsulate the parsing and decoding of mime headers.


As an example, the following test snippet will fail as the current SubjectSpecification does not take into account the decoding of the subject.

```php
<?php
use GuzzleHttp\Client as GuzzleClient;
use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
use Http\Message\MessageFactory\GuzzleMessageFactory;
use Illuminate\Support\Facades\Mail;
use rpkamp\Mailhog\MailhogClient;
use rpkamp\Mailhog\Specification\SubjectSpecification;

public function testUf8()
{
    $adapter = new GuzzleAdapter(new GuzzleClient());
    $requestFactory = new GuzzleMessageFactory();
    $client = new MailhogClient($adapter, $requestFactory, env('MAILHOG_API_BASEURL'));
    $client->purgeMessages();


    $subject = 'Mailhog é muito bom mesmo: açãoéôÍ';
    // This is encoded as: Mailhog =?utf-8?Q?=C3=A9?= muito bom mesmo: =?utf-8?Q?a=C3=A7=C3=A3o=C3=A9=C3=B4=C3=8D?=

    Mail::to(['foo@bar.com'])->send(new HtmlMailable($subject, 'foobar'));

    $messages = $client->findMessagesSatisfying(new SubjectSpecification($subject));

    // This assertion fails
    $this->assertCount(1, $messages);
}   
```

The web UI of mailhog implements some logic to decode mime headers and display the correct text to the user as can be seen [here](https://github.com/mailhog/MailHog-UI/blob/24b31a47cc5b65d23576bb9884c941d2b88381f7/assets/js/strutil.js) in the `unescapeFromMime` function.

In PHP this implementation is way easier because we have a [built-in function](https://www.php.net/manual/en/function.iconv-mime-decode.php) for this.