### PR TITLE
Pin GitHub Actions on Ubuntu 18.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         ports:
           - 2025:2025
           - 9025:9025
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Test
     strategy:
       fail-fast: false


### PR DESCRIPTION
Ubuntu 20.04 only supports PHP 7.4 and 8.0, so older versions can't be
tested there.