### PR TITLE
PHP 8.4 str_getcsv() deprecation

### DIFF
--- a/src/Message/ContactCollection.php
+++ b/src/Message/ContactCollection.php
@@ -36,7 +36,7 @@ class ContactCollection implements Countable, IteratorAggregate
                 static function (string $contact) {
                     return Contact::fromString($contact);
                 },
-                array_map('trim', str_getcsv($contacts))
+                array_map('trim', str_getcsv($contacts, escape: '\\'))
             )
         );
     }


### PR DESCRIPTION
str_getcsv(): the $escape parameter must be provided as its default value will change